### PR TITLE
[fix] Workaround for devices which show zero CPUs

### DIFF
--- a/openwisp-monitoring/files/lib/openwisp-monitoring/resources.lua
+++ b/openwisp-monitoring/files/lib/openwisp-monitoring/resources.lua
@@ -35,6 +35,10 @@ function resources.get_cpus()
   local processors = processors_file:read('*a')
   processors_file:close()
   local cpus = tonumber(processors)
+  -- assume the hardware has at least 1 proc
+  if cpus == 0 then
+    return 1
+  end
   return cpus
 end
 


### PR DESCRIPTION
In some rare cases it may happen that the hardware
mistakenly reports zero CPUs, in these cases we can
assume there's at least 1 CPU.

If the hardware has more than 1 CPU the load average
will still be wrong.