### PR TITLE
[change!] Use randomized backoff instead of exponential backoff #107

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Agent will check if any data file is available in temporary storage.
 If there is no data file, the agent will sleep for the time interval and check for the data file again. This will be continued until a data file is found.
 If a signal is received from the other agent, then the sleep will be interrupted and agent will start sending data.
 
-If agent fails to send data to the server, an exponential backoff will be used to retry until `max_retries` is reached.
+If agent fails to send data to the server, a randomized backoff (between 2 and 15 seconds) will be used to retry until `max_retries` is reached.
 If all attempts of sending data failed, the agent will try to send data in the next cycle.
 
 If data is sent successfully, then the data file will be deleted and agent will look for another file.

--- a/openwisp-monitoring/files/monitoring.agent
+++ b/openwisp-monitoring/files/monitoring.agent
@@ -140,7 +140,6 @@ send_data() {
 			url="$URL&time=$filename.000000"
 			# retry sending data in case of failure
 			failures=0
-			timeout=1
 			# check if the data is latest or old one
 			[ "$(echo "$TMP_DIR"/* | awk '{print $2}')" ] || url="$url&current=true"
 			if [ "${basefilename##*.}" = "gz" ]; then
@@ -183,7 +182,7 @@ send_data() {
 					rm -f "$filename"
 					break
 				else
-					timeout=$((timeout * 2))
+					timeout=$(/usr/sbin/openwisp-get-random-number 2 15)
 					[ "$VERBOSE_MODE" -eq "1" ] && logger -s "Data not sent successfully. Retrying in $timeout seconds" \
 						-p daemon.warn
 					failures=$((failures + 1))


### PR DESCRIPTION
Instead of using exponential backoff, the package will use a random value between 2 and 15 seconds before retrying to perform HTTP request for uploading metrics to the controller.

Closes #107