### PR TITLE
[chores] Added `.gitignore` to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Exclude luacov stats files
+openwisp-monitoring/tests/luacov.stats.out
+openwisp-monitoring/tests/luacov.report.out
+
+# Compiled Lua sources
+luac.out
+
+# luarocks build files
+*.src.rock
+*.zip
+*.tar.gz
+
+# Object files
+*.o
+*.os
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+*.def
+*.exp
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex


### PR DESCRIPTION
`luacov` creates stats files in the `openwisp-monitoring/tests/` directory when we run the `./runtests` script.
- Added basic lua `.gitignore` template to the project repository.