### PR TITLE
[ci] Execute tests even if QA checks fail, build anyway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
-name: OpenWRT OPENWISP MONITORING CI Build
+---
+
+name: OpenWRT OpenWISP Monitoring CI Build
 
 on:
   push:
@@ -22,11 +24,11 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Install Python dependencies
-        run: pip install openwisp-utils[qa]
-
-      - name: Install Development dependencies
-        run: sudo ./install-dev.sh
+      - name: Install dependencies
+        id: deps
+        run: |
+          pip install openwisp-utils[qa]
+          sudo ./install-dev.sh
 
       - name: QA-Checks
         run: ./run-qa-checks
@@ -41,9 +43,11 @@ jobs:
           sh_checker_comment: true
 
       - name: Tests
+        if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
         run: ./runtests
 
       - name: Upload Coverage
+        if: ${{ success() }}
         run: |
           cd openwisp-monitoring/tests
           luacov-coveralls -v
@@ -52,7 +56,6 @@ jobs:
 
   build:
     name: Build and upload package as artifacts
-    needs: tests
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: '/home/runner/work/build'
@@ -87,6 +90,7 @@ jobs:
           CI_CACHE: ${{ steps.cache.outputs.cache-hit }}
 
       - name: Upload packages as artifacts
+        if: ${{ github.event_name=='push' }}
         uses: actions/upload-artifact@v2
         with:
           name: Packages


### PR DESCRIPTION
Let's not stop testing if QA checks fail.
Let's build in any case to make sure build errors are spotted also if tests fail.
If a PR from a new contributor doesn't look good we can avoid running the build entirely.