### PR TITLE
[feature] Allow not depending on rpcd-mod-iwinfo

### DIFF
--- a/openwisp-monitoring/Config.in
+++ b/openwisp-monitoring/Config.in
@@ -1,0 +1,9 @@
+menu "netjson-monitoring Configuration"
+
+config NETJSON_MONITORING_IWINFO
+	bool "Enable rpcd-mod-iwinfo"
+	default y
+	help
+	  Whether to include the rpcd-mod-iwinfo dependency (enabled by default).
+
+endmenu

--- a/openwisp-monitoring/Makefile
+++ b/openwisp-monitoring/Makefile
@@ -25,13 +25,18 @@ define Package/openwisp-monitoring
 endef
 
 define Package/netjson-monitoring
-	TITLE:=NetJson Monitoring
+	TITLE:=NetJSON Monitoring
 	CATEGORY:=Administration
 	SECTION:=admin
 	SUBMENU:=openwisp
-	DEPENDS:=+libubus-lua +lua-cjson +rpcd +rpcd-mod-iwinfo
+	DEPENDS:=+libubus-lua +lua-cjson +rpcd
+	DEPENDS+=+NETJSON_MONITORING_IWINFO:rpcd-mod-iwinfo
 	PKGARCH:=all
 	URL:=http://openwisp.org
+endef
+
+define Package/netjson-monitoring/config
+	source "$(SOURCE)/Config.in"
 endef
 
 define Build/Compile
@@ -84,8 +89,12 @@ define Package/netjson-monitoring/install
 		files/lib/openwisp-monitoring/wifi.lua \
 		$(1)/usr/lib/lua/openwisp-monitoring/wifi.lua
 
-	$(CP) ../VERSION $(1)/usr/lib/openwisp-monitoring/
+	# Iwinfo is enabled by default unless specified otherwise
+	$(INSTALL_DIR) $(1)/usr/lib/lua/openwisp-monitoring
+	sed 's/true/$(if $(CONFIG_NETJSON_MONITORING_IWINFO),true,false)/' \
+		files/lib/openwisp-monitoring/iwinfo.lua > $(1)/usr/lib/lua/openwisp-monitoring/iwinfo.lua
 
+	$(CP) ../VERSION $(1)/usr/lib/openwisp-monitoring/
 endef
 
 define Package/openwisp-monitoring/install
@@ -103,7 +112,7 @@ define Package/openwisp-monitoring/install
 	$(INSTALL_BIN) \
 		files/monitoring.init \
 		$(1)/etc/init.d/openwisp-monitoring
-	
+
 	$(INSTALL_BIN) \
 		files/openwisp-monitoring.hotplug \
 		$(1)/etc/hotplug.d/openwisp/openwisp-monitoring

--- a/openwisp-monitoring/files/lib/openwisp-monitoring/iwinfo.lua
+++ b/openwisp-monitoring/files/lib/openwisp-monitoring/iwinfo.lua
@@ -1,0 +1,3 @@
+return {
+  enabled = true
+}

--- a/openwisp-monitoring/files/lib/openwisp-monitoring/monitoring.lua
+++ b/openwisp-monitoring/files/lib/openwisp-monitoring/monitoring.lua
@@ -8,5 +8,6 @@ monitoring.neighbors = require('openwisp-monitoring.neighbors')
 monitoring.resources = require('openwisp-monitoring.resources')
 monitoring.utils = require('openwisp-monitoring.utils')
 monitoring.wifi = require('openwisp-monitoring.wifi')
+monitoring.iwinfo = require('openwisp-monitoring.iwinfo')
 
 return monitoring

--- a/openwisp-monitoring/files/sbin/netjson-monitoring.lua
+++ b/openwisp-monitoring/files/sbin/netjson-monitoring.lua
@@ -78,6 +78,10 @@ local function get_wireless_netjson_interface(radio, name, iwinfo)
     name = name,
     type = 'wireless',
   }
+  -- iwinfo disabled
+  if iwinfo == nil then
+    return netjson_interface
+  end
   -- if channel is missing the WiFi interface is not fully up
   -- and hence we avoid including its info because it will be rejected
   if monitoring.utils.is_empty(iwinfo.channel) == false then
@@ -117,7 +121,10 @@ for _, radio in pairs(wireless_status) do
   for _, interface in ipairs(radio.interfaces) do
     local name = interface.ifname
     if name and not monitoring.utils.is_excluded(name) then
-      local iwinfo = ubus:call('iwinfo', 'info', {device = name})
+      local iwinfo = nil
+      if monitoring.iwinfo.enabled then
+        iwinfo = ubus:call('iwinfo', 'info', {device = name})
+      end
       wireless_interfaces[name] = get_wireless_netjson_interface(radio, name, iwinfo)
     end
   end


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

On space constraint devices which do not have a WiFi card, it is useful to avoid including rpcd-mod-iwinfo and its dependencies.