### PR TITLE
[fix] Simplified compiling package without iwinfo

### DIFF
--- a/openwisp-monitoring/Makefile
+++ b/openwisp-monitoring/Makefile
@@ -89,10 +89,10 @@ define Package/netjson-monitoring/install
 		files/lib/openwisp-monitoring/wifi.lua \
 		$(1)/usr/lib/lua/openwisp-monitoring/wifi.lua
 
-	# Iwinfo is enabled by default unless specified otherwise
-	$(INSTALL_DIR) $(1)/usr/lib/lua/openwisp-monitoring
-	sed 's/true/$(if $(CONFIG_NETJSON_MONITORING_IWINFO),true,false)/' \
-		files/lib/openwisp-monitoring/iwinfo.lua > $(1)/usr/lib/lua/openwisp-monitoring/iwinfo.lua
+# Iwinfo is enabled by default unless specified otherwise
+ifeq ($(CONFIG_NETJSON_MONITORING_IWINFO), y)
+	$(CP) files/lib/openwisp-monitoring/iwinfo.lua $(1)/usr/lib/lua/openwisp-monitoring/iwinfo.lua
+endif
 
 	$(CP) ../VERSION $(1)/usr/lib/openwisp-monitoring/
 endef

--- a/openwisp-monitoring/files/lib/openwisp-monitoring/monitoring.lua
+++ b/openwisp-monitoring/files/lib/openwisp-monitoring/monitoring.lua
@@ -8,6 +8,14 @@ monitoring.neighbors = require('openwisp-monitoring.neighbors')
 monitoring.resources = require('openwisp-monitoring.resources')
 monitoring.utils = require('openwisp-monitoring.utils')
 monitoring.wifi = require('openwisp-monitoring.wifi')
-monitoring.iwinfo = require('openwisp-monitoring.iwinfo')
+
+local success, iwinfo = pcall(require, 'openwisp-monitoring.iwinfo')
+if success then
+  monitoring.iwinfo = iwinfo
+else
+  monitoring.iwinfo = {
+    enabled = false
+  }
+end
 
 return monitoring


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Copy iwinfo.lua only when CONFIG_NETJSON_MONITORING_IWINFO is set to true.
