### PR TITLE
fix Invalid data in openwisp2.log

### DIFF
--- a/openwisp-monitoring/files/lib/openwisp-monitoring/wifi.lua
+++ b/openwisp-monitoring/files/lib/openwisp-monitoring/wifi.lua
@@ -27,7 +27,7 @@ function wifi.invert_rx_tx(interface)
 end
 
 function wifi.parse_hostapd_clients(clients)
-  local data = {}
+  local data
   for mac, properties in pairs(clients) do
     properties.mac = mac
     table.insert(data, properties)
@@ -36,7 +36,7 @@ function wifi.parse_hostapd_clients(clients)
 end
 
 function wifi.parse_iwinfo_clients(clients)
-  local data = {}
+  local data
   for _, p in pairs(clients) do
     local client = {}
     client.mac = p.mac


### PR DESCRIPTION
```
Invalid data in "#/interfaces/3/wireless/clients", validator says:

{} is not of type 'array'
```

## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.
