### PR TITLE
fix Invalid data in openwisp2.log

### DIFF
--- a/openwisp-monitoring/files/lib/openwisp-monitoring/wifi.lua
+++ b/openwisp-monitoring/files/lib/openwisp-monitoring/wifi.lua
@@ -32,7 +32,7 @@ function wifi.parse_hostapd_clients(clients)
     properties.mac = mac
     table.insert(data, properties)
   end
-  return data
+  if #data > 0 then return data end
 end
 
 function wifi.parse_iwinfo_clients(clients)
@@ -62,7 +62,7 @@ function wifi.parse_iwinfo_clients(clients)
     end
     table.insert(data, client)
   end
-  return data
+  if #data > 0 then return data end
 end
 
 -- takes ubus wireless.status clients output and converts it to NetJSON

--- a/openwisp-monitoring/tests/test_wifi.lua
+++ b/openwisp-monitoring/tests/test_wifi.lua
@@ -64,7 +64,7 @@ function TestWifi.test_parse_hostapd_clients()
   luaunit.assertEquals(wifi_functions.parse_hostapd_clients(wifi_data.wlan1_clients),
     wifi_data.parsed_clients)
   luaunit.assertEquals(wifi_functions.parse_hostapd_clients(wifi_data.wlan2_clients),
-    {})
+    nil)
 end
 
 function TestWifi.test_parse_iwinfo_clients()
@@ -79,7 +79,7 @@ function TestWifi.test_netjson_clients()
   luaunit.assertEquals(wifi_functions.netjson_clients(wifi_data.wlan1_clients, false),
     wifi_data.parsed_clients)
   luaunit.assertEquals(wifi_functions.netjson_clients(wifi_data.wlan2_clients, false),
-    {})
+    nil)
   -- testing iwinfo clients
   luaunit.assertEquals(
     wifi_functions.netjson_clients(wifi_data.mesh0_clients.results, true),


### PR DESCRIPTION
```
Invalid data in "#/interfaces/3/wireless/clients", validator says:

{} is not of type 'array'
```

## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.
