### PR TITLE
monitoring.agent: check if data filename exist.

### DIFF
--- a/openwisp-monitoring/files/monitoring.agent
+++ b/openwisp-monitoring/files/monitoring.agent
@@ -150,7 +150,14 @@ send_data() {
 				gzip -d "$file"
 			fi
 			filename="$TMP_DIR/$filename"
-			data=$(cat "$filename")
+			# check if the data file exist
+			if [ -f "$filename" ] ; then
+				data=$(cat "$filename")
+			else
+				[ "$VERBOSE_MODE" -eq "1" ] && logger -s "data file $filename not found." \
+					-p daemon.info
+				continue
+			fi
 			while true; do
 				if [ "$failures" -eq "$MAX_RETRIES" ]; then
 					[ -f "$RESPONSE_FILE" ] && error_message="\"$(cat "$RESPONSE_FILE")\"" || error_message='"".'


### PR DESCRIPTION
This happens in very rare cases.

fix Invalid data in openwisp2.log
```
[INFO 2025-02-07 13:56:57,767] module: views, process: 135817, thread: 139275812288320
Invalid data in "#/interfaces/3/wireless/clients/1/he", validator says:

None is not of type 'boolean'

[WARNING 2025-02-07 13:56:57,768] module: log, process: 135817, thread: 139275812288320
Bad Request: /api/v1/monitoring/device/d94***569/
```
```
Fri Feb  7 13:56:57 2025 daemon.err openwisp-monitoring[9358]: cat: can't open '/tmp/openwisp/monitoring/07-02-2025_12:56:57': No such file or directory
```

## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #<issue-number>.

Please [open a new issue](https://github.com/openwisp/openwrt-openwisp-monitoring/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Please describe these changes.

## Screenshot

Please include any relevant screenshots.
