### PR TITLE
[fix] Switch to portable df output (df -P)

### DIFF
--- a/openwisp-monitoring/files/lib/openwisp-monitoring/resources.lua
+++ b/openwisp-monitoring/files/lib/openwisp-monitoring/resources.lua
@@ -6,7 +6,7 @@ local resources = {}
 
 function resources.parse_disk_usage()
   local disk_usage_info = {}
-  local disk_usage_file = io.popen('df')
+  local disk_usage_file = io.popen('df -P')
   local disk_usage = disk_usage_file:read("*a")
   disk_usage_file:close()
   for _, line in ipairs(utils.split(disk_usage, "\n")) do

--- a/openwisp-monitoring/tests/main_env.lua
+++ b/openwisp-monitoring/tests/main_env.lua
@@ -39,7 +39,7 @@ env.uci = {
 
 env.io = {
   popen = function(arg)
-    if arg == 'df' then
+    if arg == 'df -P' then
       return io.open(test_file_dir .. 'disk_usage.txt')
     elseif arg == 'cat /proc/cpuinfo | grep -c processor' then
       local f = assert(io.tmpfile())

--- a/openwisp-monitoring/tests/test_resources.lua
+++ b/openwisp-monitoring/tests/test_resources.lua
@@ -43,7 +43,7 @@ function TestNetJSON.test_resources()
         f:write('0.37 0.95 1.23 2/873 56899\n')
         f:seek('set', 0)
         return f
-      elseif arg == 'df' then
+      elseif arg == 'df -P' then
         return io.open(test_file_dir .. 'disk_usage.txt')
       elseif arg == 'cat /proc/cpuinfo | grep -c processor' then
         f:write('8')


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #153 

## Description of Changes

Changed df to `df -P` (POSIX output to prevent newline for long filesystem names).