### PR TITLE
Fix bad pgrep / kill

### DIFF
--- a/openwisp-monitoring/files/monitoring.agent
+++ b/openwisp-monitoring/files/monitoring.agent
@@ -109,8 +109,8 @@ save_data() {
 				-p daemon.info
 		fi
 		# get process id of the process sending data
-		pid=$(pgrep -f "openwisp-monitoring.*--mode send")
-		kill -SIGUSR1 "$pid"
+		pid=$(pgrep -P 1 -f "openwisp-monitoring.*--mode send")
+		kill -SIGUSR1 $pid
 		sleep "$INTERVAL"
 	done
 }
@@ -212,8 +212,8 @@ send_data() {
 								-t openwisp-monitoring \
 								-p daemon.err
 							# get process id of the process collecting data
-							pid=$(pgrep -f "openwisp-monitoring.*--mode collect")
-							kill -SIGKILL "$pid"
+							pid=$(pgrep -P 1 -f "openwisp-monitoring.*--mode collect")
+							kill -SIGKILL $pid
 							exit 2
 						fi
 					fi


### PR DESCRIPTION
It's common to have forks of openwisp-monitoring due to use of $(some_command), so this can return more than one PID. Further, by calling kill "$pid" we just end up with an error about the parameter not being an integer.

## Checklist

- [no] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [yes] I have manually tested the changes proposed in this pull request.
- [n/a] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [n/a] I have updated the documentation.

## Reference to Existing Issue

Closes #157 

Please [open a new issue](https://github.com/openwisp/openwrt-openwisp-monitoring/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Only pick process whose parent is init, ignore others

