### PR TITLE
[fix] Avoid failure if ubus objects not registered

### DIFF
--- a/openwisp-monitoring/files/sbin/netjson-monitoring.lua
+++ b/openwisp-monitoring/files/sbin/netjson-monitoring.lua
@@ -101,7 +101,8 @@ local function get_wireless_netjson_interface(radio, name, iwinfo)
     }
     if iwinfo.mode == 'Ad-Hoc' or iwinfo.mode == 'Mesh Point' or iwinfo.mode ==
       'Client' then
-      clients = ubus:call('iwinfo', 'assoclist', {device = name}).results
+      local assoclist = ubus:call('iwinfo', 'assoclist', {device = name})
+      clients = assoclist and assoclist.results
       is_mesh = true
     else
       local hostapd_output = ubus:call('hostapd.' .. name, 'get_clients', {})
@@ -117,7 +118,7 @@ end
 
 -- collect relevant wireless interface stats
 -- (traffic and connected clients)
-for _, radio in pairs(wireless_status) do
+for _, radio in pairs(wireless_status or {}) do
   for _, interface in ipairs(radio.interfaces) do
     local name = interface.ifname
     if name and not monitoring.utils.is_excluded(name) then
@@ -131,7 +132,7 @@ for _, radio in pairs(wireless_status) do
 end
 
 -- collect interface stats
-for name, interface in pairs(network_status) do
+for name, interface in pairs(network_status or {}) do
   -- only collect data from iterfaces which have not been excluded
   if not monitoring.utils.is_excluded(name) then
     local netjson_interface = {

--- a/openwisp-monitoring/tests/test_interfaces.lua
+++ b/openwisp-monitoring/tests/test_interfaces.lua
@@ -202,4 +202,33 @@ function TestNetJSON.test_virtual_interface_type()
   luaunit.assertEquals(netjson["interfaces"][4]["name"], "wg0")
 end
 
+function TestNetJSON.test_no_wireless_ubus_object()
+  -- simulate a container with no radios: network.wireless is not registered
+  package.loaded.ubus = {
+    connect = function()
+      return {
+        call = function(...)
+          local arg = {...}
+          if arg[2] == 'system' and arg[3] == 'board' then
+            return {hostname = "08-00-27-56-92-F5"}
+          elseif arg[2] == 'system' and arg[3] == 'info' then
+            return {memory = nil, local_time = nil, uptime = nil, swap = nil}
+          elseif arg[2] == 'network.device' and arg[3] == 'status' then
+            return require('test_files/network_data').devices
+          elseif arg[2] == 'network.interface' and arg[3] == 'dump' then
+            return require('test_files/interface_data').interface_data
+          elseif arg[2] == 'network.wireless' then
+            return nil
+          else
+            return {}
+          end
+        end
+      }
+    end
+  }
+  local netjson_file = assert(loadfile('../files/sbin/netjson-monitoring.lua'))
+  local netjson = cjson.decode(netjson_file('*'))
+  luaunit.assertNotNil(netjson["interfaces"])
+end
+
 os.exit(luaunit.LuaUnit.run())


### PR DESCRIPTION
On certain systems like Linux containers, some ubus objects may not be registered (eg: network.wireless), and hence the agent needs to handle these cases gracefully.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.