### PR TITLE
[ci] Generate and upload sha256 checksum of compiled packages #74

### DIFF
--- a/runbuild
+++ b/runbuild
@@ -46,6 +46,10 @@ sed -i '/routing/d' feeds.conf
 } >>.config
 make defconfig
 
+# disable package signing: make defconfig sets CONFIG_SIGNED_PACKAGES=y by default
+# but usign is not available in CI, so we disable it to allow index generation
+sed -i 's/^CONFIG_SIGNED_PACKAGES=y$/CONFIG_SIGNED_PACKAGES=/' .config
+
 if [ ! "$CI_CACHE" ]; then
 	make -j"$CORES" tools/install
 	make -j"$CORES" toolchain/install
@@ -53,6 +57,16 @@ fi
 
 make -j"$CORES" package/openwisp-monitoring/compile \
 	|| make -j1 V=s package/openwisp-monitoring/compile || exit 1
+
+# generate package index and publish checksum for package verification
+make package/index V=s
+PACKAGES_FILE="$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp_monitoring/Packages"
+
+if [ ! -f "$PACKAGES_FILE" ]; then
+	echo "ERROR: Packages file not found at $PACKAGES_FILE"
+	exit 1
+fi
+cp "$PACKAGES_FILE" "$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp_monitoring/Packages.sha256.checksum"
 
 mv "$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp_monitoring" "$VERSIONED_DIR"
 


### PR DESCRIPTION
Implement package checksum publishing to enable users to verify downloaded packages for authenticity.


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #74 .

Taking inspiration from [this](https://github.com/openwisp/openwisp-config/pull/242) PR. 

**Changes:**
- Disable CONFIG_SIGNED_PACKAGES in .config to skip usign requirement
  (usign is not available in CI environment)
- Generate package index with checksums using make package/index
- Copy Packages file as Packages.sha256.checksum
- Add validation to ensure Packages file is generated and not empty


## Screenshot

NA
