### PR TITLE
[ci] Upload only the Package.manifest file (instead of different files) #74

### DIFF
--- a/runbuild
+++ b/runbuild
@@ -58,16 +58,19 @@ fi
 make -j"$CORES" package/openwisp-monitoring/compile \
 	|| make -j1 V=s package/openwisp-monitoring/compile || exit 1
 
-# generate package index and publish checksum for package verification
+# Publish sha256.manifest (renamed from Package.manifest) for integrity verification
 make package/index V=s
-PACKAGES_FILE="$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp_monitoring/Packages"
-
-if [ ! -f "$PACKAGES_FILE" ]; then
-	echo "ERROR: Packages file not found at $PACKAGES_FILE"
+PACKAGES_DIR="$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp_monitoring"
+MANIFEST_FILE="$PACKAGES_DIR/Packages.manifest"
+if [ ! -f "$MANIFEST_FILE" ]; then
+	echo "ERROR: Package manifest file not found at $MANIFEST_FILE"
 	exit 1
 fi
-cp "$PACKAGES_FILE" "$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp_monitoring/Packages.sha256.checksum"
+mv "$MANIFEST_FILE" "$PACKAGES_DIR/sha256.manifest"
+rm "$BUILD_DIR"/openwrt/bin/packages/"$COMPILE_TARGET"/openwisp_monitoring/*.json
+rm "$BUILD_DIR"/openwrt/bin/packages/"$COMPILE_TARGET"/openwisp_monitoring/Packages*
 
+# Move artifacts
 mv "$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp_monitoring" "$VERSIONED_DIR"
 
 rm "$LATEST_LINK" || true

--- a/runbuild
+++ b/runbuild
@@ -4,16 +4,16 @@
 # requires the following env vars:
 # - $BUILD_DIR
 # - $DOWNLOADS_DIR
-# - $CORES (defaults to 1)
+# - $CORES (defaults to number of CPU cores on system)
 set -e
 
-BUILD_DIR=${BUILD_DIR-./build}
-DOWNLOADS_DIR=${DOWNLOADS_DIR-./downloads}
+BUILD_DIR=${BUILD_DIR-$(pwd)/build}
+DOWNLOADS_DIR=${DOWNLOADS_DIR-$(pwd)/downloads}
 START_TIME=${START_TIME-$(date +"%Y-%m-%d-%H%M%S")}
 VERSIONED_DIR="$DOWNLOADS_DIR/$START_TIME"
 COMPILE_TARGET=${COMPILE_TARGET-mips_24kc}
 LATEST_LINK="$DOWNLOADS_DIR/latest"
-CORES=${CORES:-1}
+CORES=${CORES:-$(nproc)}
 CURRENT_DIR=$(pwd)
 OPENWRT_BRANCH="openwrt-24.10"
 
@@ -73,5 +73,5 @@ rm "$BUILD_DIR"/openwrt/bin/packages/"$COMPILE_TARGET"/openwisp_monitoring/Packa
 # Move artifacts
 mv "$BUILD_DIR/openwrt/bin/packages/$COMPILE_TARGET/openwisp_monitoring" "$VERSIONED_DIR"
 
-rm "$LATEST_LINK" || true
+rm -f "$LATEST_LINK"
 ln -s "$VERSIONED_DIR" "$LATEST_LINK"


### PR DESCRIPTION
Related to #74.

Avoids bloating downloads.openwisp.io with too many files, we only need `Package.manifest`.